### PR TITLE
Allow generating youtubeunblocked links directly

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,59 +1,53 @@
 // --- basic helpers
 const ytInput = document.getElementById('ytUrl');
-const openBtn = document.getElementById('openSite');
+const generateBtn = document.getElementById('generateLink');
 const copyInputBtn = document.getElementById('copyInput');
-const autofillLink = document.getElementById('autofillLink');
-const copyUrlLink = document.getElementById('copyUrlLink');
+const resultCard = document.getElementById('resultCard');
+const resultUrlEl = document.getElementById('resultUrl');
+const copyResultBtn = document.getElementById('copyResult');
+const resultStatus = document.getElementById('resultStatus');
 
-openBtn.addEventListener('click', () => {
-  window.open('https://youtubeunblocked.live', '_blank', 'noopener');
+generateBtn.addEventListener('click', async () => {
+  const raw = ytInput.value.trim();
+  if (!raw) {
+    alert('Enter a YouTube link to convert.');
+    ytInput.focus();
+    return;
+  }
+
+  const proxyUrl = buildProxyUrl(raw);
+  if (!proxyUrl) {
+    alert('That does not look like a valid YouTube link.');
+    return;
+  }
+
+  if (resultUrlEl) resultUrlEl.textContent = proxyUrl;
+  showResultCard('Copied unblocked link to clipboard.');
+  const copied = await copyText(proxyUrl, 'Unblocked link copied to clipboard.');
+  if (!copied) toast('Link ready below. Tap copy if needed.');
+
+  if (resultStatus) {
+    const ts = new Date().toLocaleTimeString();
+    resultStatus.textContent = `Generated at ${ts}`;
+  }
 });
 
 copyInputBtn.addEventListener('click', async () => {
   const v = ytInput.value.trim();
   if (!v) return alert('Add a YouTube URL first.');
-  try {
-    await navigator.clipboard.writeText(v);
-    toast('Input URL copied to clipboard.');
-  } catch {
-    fallbackCopy(v);
-  }
+  await copyText(v, 'Original link copied to clipboard.');
 });
 
-// --- Bookmarklet generators -------------------------------------------
-// 1) Autofill & Go (runs ON youtubeunblocked.live). Prompts for URL.
-const autofillCode = `
-javascript:(async()=>{try{
-  const u = prompt('YouTube URL to unblock:');
-  if(!u) return;
-  const pick = (...sels)=>sels.map(s=>document.querySelector(s)).find(Boolean);
-  const input = pick(
-    'input[name="url"]','input#url','input[type="url"]','input[type="text"]',
-    'textarea[name="url"]','textarea',
-    'input[placeholder*="Enter an URL" i]','input[placeholder*="URL" i]',
-    'input[placeholder*="search" i]','input[aria-label*="url" i]'
-  );
-  if(!input){ alert('Could not find the URL field.'); return; }
-  input.value=''; input.dispatchEvent(new Event('input',{bubbles:true}));
-  input.focus(); document.execCommand('insertText',false,u);
-  const btn = Array.from(document.querySelectorAll('button,input[type=submit],a'))
-    .find(el => /\\b(go!?|unblock|generate|submit)\\b/i.test((el.textContent||el.value||'')));
-  setTimeout(()=>{ (btn && btn.click()) || input.closest('form')?.submit(); }, 150);
-}catch(e){ alert('Autofill error: '+e.message); }})();`;
+copyResultBtn?.addEventListener('click', async () => {
+  const text = resultUrlEl?.textContent?.trim();
+  if (!text || text.includes('…')) {
+    alert('Generate an unblocked link first.');
+    return;
+  }
+  await copyText(text, 'Unblocked link copied again.');
+});
 
-// 2) Copy current page URL (run after the proxy opens the video)
-const copyUrlCode = `
-javascript:(()=>{const t=location.href;
-  (navigator.clipboard?navigator.clipboard.writeText(t).then(()=>alert('Copied link to clipboard!')).catch(()=>fc()):fc());
-  function fc(){const ta=document.createElement('textarea'); ta.value=t; document.body.appendChild(ta);
-    ta.select(); document.execCommand('copy'); ta.remove(); alert('Copied link (fallback).');}
-})();`;
-
-// Set bookmarklet hrefs
-autofillLink.href = autofillCode.trim();
-copyUrlLink.href = copyUrlCode.trim();
-
-// --- tiny toast
+// --- tiny toast ---------------------------------------------------------
 function toast(msg){
   const el = document.createElement('div');
   el.textContent = msg;
@@ -65,8 +59,64 @@ function toast(msg){
   document.body.appendChild(el);
   setTimeout(()=>el.remove(), 1800);
 }
-function fallbackCopy(text){
+function fallbackCopy(text, msg='Copied (fallback).'){
   const ta=document.createElement('textarea');
   ta.value=text; document.body.appendChild(ta); ta.select();
-  document.execCommand('copy'); ta.remove(); toast('Copied (fallback).');
+  document.execCommand('copy'); ta.remove(); toast(msg);
+}
+async function copyText(text, message){
+  if (!text) return false;
+  try {
+    await navigator.clipboard.writeText(text);
+    if (message) toast(message);
+    return true;
+  } catch {
+    fallbackCopy(text, message || 'Copied (fallback).');
+    return false;
+  }
+}
+function showResultCard(status){
+  if (!resultCard) return;
+  resultCard.classList.remove('hidden');
+  if (status && resultStatus) resultStatus.textContent = status;
+}
+
+function buildProxyUrl(raw){
+  if (!raw) return null;
+
+  let value = raw.trim();
+  if (!value) return null;
+
+  if (!/^[a-zA-Z][\w+.-]*:/.test(value)) {
+    value = `https://${value}`;
+  }
+
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+
+  const hostname = url.hostname.replace(/^www\./i, '').toLowerCase();
+
+  if (hostname === 'youtu.be') {
+    const id = url.pathname.replace(/^\//, '').trim();
+    if (!id) return null;
+    const proxy = new URL('https://youtubeunblocked.live/watch');
+    proxy.searchParams.set('v', id);
+    url.searchParams.forEach((v, key) => {
+      if (key.toLowerCase() !== 'v') proxy.searchParams.set(key, v);
+    });
+    if (url.hash) proxy.hash = url.hash;
+    return proxy.toString();
+  }
+
+  if (hostname.endsWith('youtube.com')) {
+    url.protocol = 'https:';
+    url.hostname = 'youtubeunblocked.live';
+    return url.toString();
+  }
+
+  return null;
 }

--- a/index.html
+++ b/index.html
@@ -9,27 +9,46 @@
 <body>
   <main class="wrap">
     <h1>YT Unblocked Helper</h1>
-    <p class="sub">Paste a YouTube link, get a youtubeunblocked.live version instantly.</p>
+    <p class="sub">Paste a YouTube link. We'll hand you a youtubeunblocked.live URL instantly.</p>
 
-    <section class="card">
+    <section class="card primary">
       <label for="ytUrl">YouTube URL</label>
       <input id="ytUrl" type="url" placeholder="https://www.youtube.com/watch?v=VIDEO_ID" />
       <div class="row">
         <button id="generateLink">Get unblocked link</button>
-        <button id="copyInput">Copy original link</button>
+        <button id="copyInput" class="secondary">Copy original link</button>
+        <button id="openSite" class="ghost" type="button">Open youtubeunblocked.live</button>
       </div>
-      <p class="hint">We keep everything on this page—no extra tabs or bookmarklets needed.</p>
+      <p class="hint">Everything happens here—no extra tabs needed. Legacy bookmarklets live below if you still need them.</p>
     </section>
 
     <section id="resultCard" class="card hidden">
       <h2>Unblocked link</h2>
       <p class="hint">Share or open this link. It points to the same video through youtubeunblocked.live.</p>
       <div class="result-box">
-        <code id="resultUrl">https://youtubeunblocked.live/…</code>
+        <code id="resultUrl" title="Generated link">https://youtubeunblocked.live/…</code>
         <button id="copyResult">Copy unblocked link</button>
       </div>
       <p id="resultStatus" class="hint"></p>
     </section>
+
+    <details class="card legacy">
+      <summary>Legacy bookmarklet workflow (optional)</summary>
+      <div class="legacy-content">
+        <section>
+          <h2>Step 1 — Install / use the Autofill bookmarklet</h2>
+          <p>Drag this to your bookmarks bar, or right-click &rarr; “Bookmark link”. Then visit youtubeunblocked.live and click it.</p>
+          <a id="autofillLink" class="bookmarklet" href="#">Autofill &amp; Go</a>
+          <p class="hint">When clicked on youtubeunblocked.live, it will prompt you for a YouTube URL, place it into the big field, and press <b>Go!</b></p>
+        </section>
+        <section>
+          <h2>Step 2 — Copy the final link</h2>
+          <p>After the proxy opens the video page, click this bookmarklet to copy the current page URL.</p>
+          <a id="copyUrlLink" class="bookmarklet" href="#">Copy Current URL</a>
+          <p class="hint">Works on most modern browsers; includes a fallback if clipboard permissions are blocked.</p>
+        </section>
+      </div>
+    </details>
 
     <footer>
       <p>Need another? Just paste a new YouTube link above.</p>

--- a/index.html
+++ b/index.html
@@ -9,33 +9,30 @@
 <body>
   <main class="wrap">
     <h1>YT Unblocked Helper</h1>
-    <p class="sub">Open the site, auto-fill a YouTube link, then copy the generated URL.</p>
+    <p class="sub">Paste a YouTube link, get a youtubeunblocked.live version instantly.</p>
 
     <section class="card">
       <label for="ytUrl">YouTube URL</label>
       <input id="ytUrl" type="url" placeholder="https://www.youtube.com/watch?v=VIDEO_ID" />
       <div class="row">
-        <button id="openSite">Open youtubeunblocked.live</button>
-        <button id="copyInput">Copy input URL</button>
+        <button id="generateLink">Get unblocked link</button>
+        <button id="copyInput">Copy original link</button>
       </div>
+      <p class="hint">We keep everything on this page—no extra tabs or bookmarklets needed.</p>
     </section>
 
-    <section class="card">
-      <h2>Step 1 — Install / use the Autofill bookmarklet</h2>
-      <p>Drag this to your bookmarks bar, or right-click &rarr; “Bookmark link”. Then visit youtubeunblocked.live and click it.</p>
-      <a id="autofillLink" class="bookmarklet" href="#">Autofill &amp; Go</a>
-      <p class="hint">When clicked on youtubeunblocked.live, it will prompt you for a YouTube URL, place it into the big field, and press <b>Go!</b></p>
-    </section>
-
-    <section class="card">
-      <h2>Step 2 — Copy the final link</h2>
-      <p>After the proxy opens the video page, click this bookmarklet to copy the current page URL.</p>
-      <a id="copyUrlLink" class="bookmarklet" href="#">Copy Current URL</a>
-      <p class="hint">Works on most modern browsers; includes a fallback if clipboard permissions are blocked.</p>
+    <section id="resultCard" class="card hidden">
+      <h2>Unblocked link</h2>
+      <p class="hint">Share or open this link. It points to the same video through youtubeunblocked.live.</p>
+      <div class="result-box">
+        <code id="resultUrl">https://youtubeunblocked.live/…</code>
+        <button id="copyResult">Copy unblocked link</button>
+      </div>
+      <p id="resultStatus" class="hint"></p>
     </section>
 
     <footer>
-      <p>Tip: you can also click “Open youtubeunblocked.live” above, then run the bookmarklet there.</p>
+      <p>Need another? Just paste a new YouTube link above.</p>
     </footer>
   </main>
 

--- a/style.css
+++ b/style.css
@@ -18,10 +18,12 @@ body {
   font: 16px/1.45 system-ui, -apple-system, Segoe UI, Roboto, Inter, Arial, sans-serif;
 }
 
+.hidden { display: none !important; }
+
 .wrap {
-  max-width: 840px;
+  max-width: 680px;
   margin: 48px auto;
-  padding: 0 16px;
+  padding: 0 16px 64px;
 }
 
 h1 { font-size: 32px; margin: 0 0 6px; }
@@ -52,9 +54,9 @@ input[type="url"]::placeholder { color: #7f8aa6; }
 
 .row { display: flex; gap: 10px; margin-top: 12px; flex-wrap: wrap; }
 
-button, .bookmarklet {
+button {
   display: inline-block;
-  padding: 10px 14px;
+  padding: 10px 18px;
   border-radius: 999px;
   background: var(--accent);
   color: #08111f;
@@ -64,11 +66,36 @@ button, .bookmarklet {
   cursor: pointer;
   transition: transform .06s ease, filter .2s ease;
 }
-button:hover, .bookmarklet:hover { filter: brightness(1.05); transform: translateY(-1px); }
-
-.bookmarklet { background: var(--accent-2); }
+button:hover { filter: brightness(1.05); transform: translateY(-1px); }
+button:active { transform: translateY(0); filter: brightness(.97); }
 
 h2 { margin: 8px 0 10px; font-size: 20px; }
 .hint { color: var(--muted); margin-top: 8px; }
 
+.result-box {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+}
+
+.result-box code {
+  display: inline-block;
+  padding: 10px 12px;
+  background: #0e1628;
+  border-radius: 12px;
+  border: 1px solid rgba(255,255,255,.08);
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 15px;
+  word-break: break-all;
+}
+
 footer { color: var(--muted); margin-top: 24px; text-align: center; }
+
+@media (max-width: 520px) {
+  .row { flex-direction: column; }
+  button { width: 100%; text-align: center; }
+  .result-box { flex-direction: column; align-items: stretch; }
+  .result-box code { width: 100%; }
+}

--- a/style.css
+++ b/style.css
@@ -21,7 +21,7 @@ body {
 .hidden { display: none !important; }
 
 .wrap {
-  max-width: 680px;
+  max-width: 760px;
   margin: 48px auto;
   padding: 0 16px 64px;
 }
@@ -37,6 +37,30 @@ h1 { font-size: 32px; margin: 0 0 6px; }
   margin: 18px 0;
   box-shadow: var(--shadow);
 }
+
+.card.primary { border-color: rgba(255,255,255,.12); }
+.card.legacy { padding: 0; overflow: hidden; }
+.card.legacy > summary {
+  cursor: pointer;
+  list-style: none;
+  padding: 18px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.card.legacy > summary::marker { content: ''; }
+.card.legacy > summary::-webkit-details-marker { display: none; }
+.card.legacy > summary::after {
+  content: '\25be';
+  margin-left: auto;
+  color: var(--muted);
+  transition: transform .2s ease;
+}
+.card.legacy[open] > summary { border-bottom: 1px solid rgba(255,255,255,.08); }
+.card.legacy[open] > summary::after { transform: rotate(-180deg); }
+.card.legacy .legacy-content { padding: 0 18px 18px; }
+.card.legacy section + section { margin-top: 18px; }
 
 label { display: block; margin-bottom: 6px; color: var(--muted); }
 
@@ -54,7 +78,7 @@ input[type="url"]::placeholder { color: #7f8aa6; }
 
 .row { display: flex; gap: 10px; margin-top: 12px; flex-wrap: wrap; }
 
-button {
+button, .bookmarklet {
   display: inline-block;
   padding: 10px 18px;
   border-radius: 999px;
@@ -66,8 +90,22 @@ button {
   cursor: pointer;
   transition: transform .06s ease, filter .2s ease;
 }
-button:hover { filter: brightness(1.05); transform: translateY(-1px); }
+button:hover, .bookmarklet:hover { filter: brightness(1.05); transform: translateY(-1px); }
 button:active { transform: translateY(0); filter: brightness(.97); }
+
+button.secondary {
+  background: transparent;
+  border: 1px solid rgba(255,255,255,.18);
+  color: var(--text);
+}
+button.ghost {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--muted);
+}
+button.ghost:hover { filter: none; color: var(--text); }
+
+.bookmarklet { background: var(--accent-2); color: #2d1800; padding: 10px 14px; }
 
 h2 { margin: 8px 0 10px; font-size: 20px; }
 .hint { color: var(--muted); margin-top: 8px; }
@@ -89,13 +127,14 @@ h2 { margin: 8px 0 10px; font-size: 20px; }
   font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
   font-size: 15px;
   word-break: break-all;
+  max-width: 100%;
 }
 
 footer { color: var(--muted); margin-top: 24px; text-align: center; }
 
 @media (max-width: 520px) {
   .row { flex-direction: column; }
-  button { width: 100%; text-align: center; }
+  button, .bookmarklet { width: 100%; text-align: center; }
   .result-box { flex-direction: column; align-items: stretch; }
   .result-box code { width: 100%; }
 }


### PR DESCRIPTION
## Summary
- replace the multi-step bookmarklet flow with a single button that turns YouTube URLs into youtubeunblocked.live links
- auto-copy the generated link while surfacing it in the result card along with generation details
- refresh the page layout and styling to reflect the simplified workflow and improve responsiveness

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e31436c45c8326bf23a2eb471598a9